### PR TITLE
Objects in loops

### DIFF
--- a/inc/rain.tpl.class.php
+++ b/inc/rain.tpl.class.php
@@ -441,7 +441,7 @@ class RainTPL{
 				$value = "\$value$loop_level";           // value
 
 				//loop code
-				$compiled_code .=  "<?php $counter=-1; if( isset($var) && is_array($var) && sizeof($var) ) foreach( $var as $key => $value ){ $counter++; ?>";
+				$compiled_code .=  "<?php $counter=-1; if( isset($var) && (is_array($var) || $var instanceof Traversable ) foreach( $var as $key => $value ){ $counter++; ?>";
 
 			}
 


### PR DESCRIPTION
Hi,
please review my change to enable traversable objects in loops. This is now denied by is_array check.
I have extended this check to accept also traversable objects (like ArrayObject).
I also removed the size_of check, because it is not necessary (foreach can handle empty collections by itself).

Best regards,
Roman
