### PR TITLE
Allow sub-classes to include pages using same sub-class

### DIFF
--- a/inc/rain.tpl.class.php
+++ b/inc/rain.tpl.class.php
@@ -415,7 +415,7 @@ class RainTPL{
 				if( isset($code[ 2 ]) ){
 					
 					//dynamic include
-					$compiled_code .= '<?php $tpl = new RainTpl;' .
+					$compiled_code .= '<?php $tpl = new '.get_class($this).';' .
 								 'if( $cache = $tpl->cache( $template = basename("'.$include_var.'") ) )' .
 								 '	echo $cache;' .
 								 'else{' .
@@ -428,7 +428,7 @@ class RainTPL{
 				else{
 	
 					//dynamic include
-					$compiled_code .= '<?php $tpl = new RainTpl;' .
+					$compiled_code .= '<?php $tpl = new '.get_class($this).';' .
 									  '$tpl_dir_temp = self::$tpl_dir;' .
 									  '$tpl->assign( $this->var );' .
 									  ( !$loop_level ? null : '$tpl->assign( "key", $key'.$loop_level.' ); $tpl->assign( "value", $value'.$loop_level.' );' ).


### PR DESCRIPTION
I've found that if I extend raintpl and build my own sub-class, when using include tags, raintpl includes the template using raintpl code (instead of the subclass behavior). With this fix the include tag will create a new instance of the class that is actually generating the parent template (the one that includes the other template). In other words, It will create a new instance of the derived class, not raintpl and therefore the behavior I need.

Code speaks better than words ;)
