### PR TITLE
Fixes #30: String interpretation issues

### DIFF
--- a/inc/rain.tpl.class.php
+++ b/inc/rain.tpl.class.php
@@ -773,6 +773,10 @@ class RainTPL{
 
 			// compile the variable for php
 			if( isset( $function ) ){
+				// FIX Issue#30: checking for plain strings
+				if (preg_match("/^(?:(?:\"(?:\\\\\"|[^\"])+\")|(?:'(?:\\\'|[^'])+'))$/is", $var))
+					$php_var = $php_left_delimiter . ( !$is_init_variable && $echo ? 'echo ' : null ) . ( $params ? "( $function( $var, $params ) )" : "$function( $var )" ) . $php_right_delimiter;
+				elseif( $php_var )
 				if( $php_var )
 					$php_var = $php_left_delimiter . ( !$is_init_variable && $echo ? 'echo ' : null ) . ( $params ? "( $function( $php_var, $params ) )" : "$function( $php_var )" ) . $php_right_delimiter;
 				else


### PR DESCRIPTION
Added a check for plain strings (single or double quoted).

This also resolves the following issue:
#### Before :

`{"my string.with a dot"|myFunction}`
outputs to
`<?php echo myFunction( my string["with a dot"] ); ?>`
which results in a parse error.
#### After :

`{"my string.with a dot"|myFunction}`
outputs to
`<?php echo myFunction( "my string.with a dot" ); ?>`
which is the expected behavior.
