### PR TITLE
Replaced isset($var) by $var !== null on line 481

### DIFF
--- a/inc/rain.tpl.class.php
+++ b/inc/rain.tpl.class.php
@@ -478,7 +478,7 @@ class RainTPL{
 				$value = "\$value$loop_level";           // value
 
 				//loop code
-				$compiled_code .=  "<?php $counter=-1; if( isset($var) && is_array($var) && sizeof($var) ) foreach( $var as $key => $value ){ $counter++; ?>";
+				$compiled_code .=  "<?php $counter=-1; if( $var !== null && is_array($var) && sizeof($var) ) foreach( $var as $key => $value ){ $counter++; ?>";
 
 			}
 

--- a/inc/rain.tpl.class.php
+++ b/inc/rain.tpl.class.php
@@ -478,7 +478,7 @@ class RainTPL{
 				$value = "\$value$loop_level";           // value
 
 				//loop code
-				$compiled_code .=  "<?php $counter=-1; if( $var !== null && is_array($var) && sizeof($var) ) foreach( $var as $key => $value ){ $counter++; ?>";
+				$compiled_code .=  "<?php $counter=-1; if( !is_null($var) && is_array($var) && sizeof($var) ) foreach( $var as $key => $value ){ $counter++; ?>";
 
 			}
 


### PR DESCRIPTION
This allows to iterate through function results (function which returns
an array for example). See issue
https://github.com/rainphp/raintpl/issues/35#issuecomment-24786805