### PR TITLE
Refactor path_replace

### DIFF
--- a/inc/rain.tpl.class.php
+++ b/inc/rain.tpl.class.php
@@ -703,8 +703,7 @@ class RainTPL{
 
 			return preg_replace_callback(
 				$exp,
-				function ($matches) {
-					global $path;
+				function ($matches) use ($path) {
 					$tag  = $matches[1];
 					$_    = $matches[2];
 					$attr = $matches[3];


### PR DESCRIPTION
Separate function to handle proper URL rewriting.

More easy-to-maintain since there is less code duplication.
More easy to customize (just add a rewriting rule at _one_ place,
saying in `rewrite_url`).

Cleanup regexps:
- (?:") = "  (not sure)
- "([^"]+?)" = "([^"]+)" = "(.+?)"  (and anyway, why a '+' and not a '*' ?)
- Isolate protocol to make it easy to add some of them

Behavior changes:
- `href=@foo@` is not a way to bypass rewriting anymore. You can still use `href = "foo"` (with spaces)
- Leading `#` in full URLs (those beginning with http or so) are trimed. This can be easily fixed.
- New protocols where added: ftp, file, apt, magnet. It is trivial to change it. (see line 658)
- Paths starting with a `/` are prefixed with base_url only, not base_url/template_dir. This is a wanted improvement.
