### PR TITLE
Fix PR #44

### DIFF
--- a/inc/rain.tpl.class.php
+++ b/inc/rain.tpl.class.php
@@ -719,9 +719,15 @@ class RainTPL{
 			$this->path = $this->reduce_path( $tpl_dir );
 
 			$exp = array();
-			$exp[] = '/<(link|a)(.*?)(href)="(.*?)"/i';
-			$exp[] = '/<(img|script|input)(.*?)(src)="(.*?)"/i';
-			$exp[] = '/<(form)(.*?)(action)="(.*?)"/i';
+
+			$tags = array_intersect( array( "link", "a" ), self::$path_replace_list );
+			$exp[] = '/<(' . join( '|', $tags ) . ')(.*?)(href)="(.*?)"/i';
+
+			$tags = array_intersect( array( "img", "script", "input" ), self::$path_replace_list );
+			$exp[] = '/<(' . join( '|', $tags ) . ')(.*?)(src)="(.*?)"/i';
+
+			$tags = array_intersect( array( "form" ), self::$path_replace_list );
+			$exp[] = '/<(' . join( '|', $tags ) . ')(.*?)(action)="(.*?)"/i';
 
 			return preg_replace_callback( $exp, 'self::single_path_replace', $html );
 


### PR DESCRIPTION
- Restore PHP 5.3 compatibility. It was broken because of the use of `$this` inside an anonymous function.
- Restore the selection of tags for which apply `path_replace` thanks to `self::$path_replace_list`. It had been unintentionnaly dropped.
- Enhance code consistency in its presentation. Especially add spaces after opening parenthesis and before closing ones.
